### PR TITLE
Investigating bugs identified by the viz

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -22,7 +22,9 @@ def init_matriarch_sim():
 
     people = ss.People(n_agents=1)
 
-    hh_demog = HouseholdResidence()
+    # if relocate_age is < pregnancy.age_min (15), females will move to a new HH
+    # before pregnancy, and thus any newborns will reside in the new HH.
+    hh_demog = HouseholdResidence(relocate_age = ss.constant(v=14))
 
     sim = ss.Sim(
         people=people, 
@@ -37,12 +39,36 @@ def init_matriarch_sim():
             # ss.Deaths(death_rate=30),  # TODO: understand odd behavior
             ],
         n_years=100,
-        rand_seed=random.randint(0, 1000))
+        rand_seed=random.randint(0, 1000),
+        slot_scale=1000 # Won't be needed in the future, but changes on a Starsim branch
+    )
     
     sim.initialize()
 
     sim.people.age[0] = 15
     sim.people.female[0] = True
-    sim.demographics["householdresidence"].huid[0] = next(hh_demog.uid_gen)
+    hh_demog = sim.demographics["householdresidence"] # Only use hh_demog create above of copy_inputs=False is passed to ss.Sim.
+    hh_demog.huid[0] = next(hh_demog.uid_gen)
 
     return sim
+
+if __name__ == '__main__':
+    sim = init_matriarch_sim()
+    sim.run()
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    fig, ax = plt.subplots()
+    n = len(sim.people.age)
+    ax.scatter(sim.people.age + 0.5*(np.random.rand(n)-0.5), sim.people.female+0.1*np.random.rand(n))
+
+    major_ticks = np.arange(0, sim.people.age.max(), 5)
+    minor_ticks = np.arange(0, sim.people.age.max(), 1)
+
+    ax.set_xticks(major_ticks)
+    ax.set_xticks(minor_ticks, minor=True)
+
+    # And a corresponding grid
+    ax.grid(which='both', axis='x')
+
+    plt.show()


### PR DESCRIPTION
* Because the initial population is just 1, but grows substantially, the default `slot_scale` value of 5 does not create a sufficient number of available slots. This results in slot redundancy and inheritance, which creates the age-sex correlation artifact. On a branch of Starsim, I added a min_slots param which defaults to 1,000 to avoid this issue. The issue can also be avoided by increasing slot_scale, as I did here. Good find!

* Class instances being fed into Starsim are copied to avoid passing the same instance to multiple Sims when doing replicates. But you had assumed the instance was not copied (which can be set by setting simulation param copy_inputs=False). This in relation to uid_gen, which was causing the first "moveout" hhid to also be 0, putting two families in the same HH. The first next was on the original object, and subsequent next calls were on the copy within Starsim.

* Regarding pregnancy between ages 15 and 50, the model is working as intended - it's a plotting / sim logic bug in relation to relocate_age. The default relocation_age as uniform 18-25, but this means women may become pregnant and "leave babies behind" in their original household -- who then become pregnant and leave more babies. Simply changing the relocate_age distribution to values below Pregnancy age_min (default 15) fixes the issue. I use ss.constant(v=14) here.

* I changed ti_relocate to age_relocate because it seemed easier and avoided ti stuff.

* Added a terrible plot to demo.py

Thanks for putting this together!